### PR TITLE
Allow Throttle to be piped to some time after instanciation

### DIFF
--- a/test/throttle.js
+++ b/test/throttle.js
@@ -167,6 +167,26 @@ describe('Throttle', function () {
     r.pipe(t);
   });
 
+  it('should work if being piped to some time after instanciation', function (done) {
+    var r = new Random(1024);
+    var t = new Throttle(1024);
+    setTimeout(
+      function () {
+        var start = Date.now();
+        var bytes = 0;
+        t.on('data', function (data) {
+          bytes += data.length;
+        });
+        t.on('end', function () {
+          assertTimespan(start, new Date(), 1000);
+          assert.equal(1024, bytes);
+          done();
+        });
+        r.pipe(t);
+      },
+      200);
+  });
+
 });
 
 function assertTimespan (start, end, expected, tolerance) {

--- a/throttle.js
+++ b/throttle.js
@@ -59,9 +59,8 @@ function Throttle (opts) {
   this.totalBytes = 0;
   this.once('pipe', () => {
     this.startTime = Date.now();
+    this._passthroughChunk();
   });
-
-  this._passthroughChunk();
 }
 inherits(Throttle, Transform);
 

--- a/throttle.js
+++ b/throttle.js
@@ -57,7 +57,9 @@ function Throttle (opts) {
   this.chunkSize = Math.max(1, opts.chunkSize);
 
   this.totalBytes = 0;
-  this.startTime = Date.now();
+  this.once('pipe', () => {
+    this.startTime = Date.now();
+  });
 
   this._passthroughChunk();
 }


### PR DESCRIPTION
The following particular edge case does not work:
```js
const throttle = new Throttle(1);
setTimeout(
  () => inputStream.pipe(throttle).pipe(outputStream),
  1000);
```
`startTime` is [defined in constructor](https://github.com/TooTallNate/node-throttle/blob/master/throttle.js#L60) and not when inputStream is piped.
This PR fixes this issue.
Thank you for sharing your great work !